### PR TITLE
Standard image size in blog post

### DIFF
--- a/src/components/postCard.astro
+++ b/src/components/postCard.astro
@@ -13,7 +13,7 @@ const {
 <li class="list-none p-0 blog">
   <article class="max-w-sm overflow-hidden bg-gray-800 rounded-xl border-2 border-gray-600 hover:scale-105 duration-500">
     <a href={permalink}>
-      <img class="w-full m-0 mb-1 rounded-t-xl" src={image} alt="Image for the post in ezpie" />
+      <img class="w-full h-44 object-contain m-0 mb-1 rounded-t-xl" src={image} alt="Image for the post in ezpie" />
       <div class="p-5">
         <h5
           class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white"


### PR DESCRIPTION
## Issue Fix
**Fixes the issue :** #19 

## Changes Made

Changed the styling to resize the Images to contain in the image tag , which will fix the bigger height images from rendering as stretchy images

## Screenshots

**Before :**

![Screenshot (93)](https://github.com/ezpie1/ezpie/assets/114584730/c25a542a-b9eb-4d96-8bb2-c0f2e7a31763)

**Fixed** 👍 

![Screenshot (92)](https://github.com/ezpie1/ezpie/assets/114584730/878ab9cd-57ea-4285-a53b-8c1ffa3eddff)

## Checklist

- [x] I have tested these changes locally.
- [x] I have followed the project's coding guidelines.
- [x] My code follows best practices.

